### PR TITLE
Fix build error by parsing fields having annotations

### DIFF
--- a/fieldgenerator/fieldgenerator-standard/src/main/java/com/speedment/jpastreamer/fieldgenerator/internal/typeparser/TypeParser.java
+++ b/fieldgenerator/fieldgenerator-standard/src/main/java/com/speedment/jpastreamer/fieldgenerator/internal/typeparser/TypeParser.java
@@ -49,6 +49,10 @@ public final class TypeParser {
     }
 
     private Node parseNode(String s) {
+        // Remove annotations in the type
+        if (s.startsWith("@")) {
+            s = s.substring(s.indexOf(' ') + 1);
+        }
         // Base case returns leaf without children
         if (!(s.contains("<") || s.contains(","))) {
             return new Node(SimpleType.create(s));

--- a/fieldgenerator/fieldgenerator-standard/src/test/java/com/speedment/jpastreamer/fieldgenerator/internal/typeparser/TypeParserTest.java
+++ b/fieldgenerator/fieldgenerator-standard/src/test/java/com/speedment/jpastreamer/fieldgenerator/internal/typeparser/TypeParserTest.java
@@ -105,4 +105,38 @@ class TypeParserTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void renderStringWithAnnotations() {
+        String type = "@javax.validation.constraints.Email,@javax.validation.constraints.Size(max=255) java.lang.String";
+        SimpleType expected = SimpleType.create("java.lang.String");
+        Type actual = typeParser.render(type);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void renderStringWithAnnotation() {
+        String type = "@javax.validation.constraints.Size(max=255) java.lang.String";
+        SimpleType expected = SimpleType.create("java.lang.String");
+        Type actual = typeParser.render(type);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void renderMapOfStringWithAnnotations() {
+        String type = "@javax.validation.constraints.Email,@javax.validation.constraints.Size(max=255) java.util.Map<java.lang.String>";
+        SimpleParameterizedType expected = SimpleParameterizedType.create(
+                SimpleType.create("java.util.Map"), SimpleType.create("java.lang.String"));
+        Type actual = typeParser.render(type);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void renderMapOfStringWithAnnotation() {
+        String type = "@javax.validation.constraints.Size(max=255) java.util.Map<java.lang.String>";
+        SimpleParameterizedType expected = SimpleParameterizedType.create(
+                SimpleType.create("java.util.Map"), SimpleType.create("java.lang.String"));
+        Type actual = typeParser.render(type);
+        assertEquals(expected, actual);
+    }
+
 }


### PR DESCRIPTION

## Code
I created an entity like this:

```java
@Getter
@Setter
@Entity
@Table(name = "my_entity")
public class MyEntity {

    @Id
    @Column(name = "id")
    private long id;

    @Email
    @Size(max = 255)
    @Column(name = "email", nullable = false)
    private String email;

}
```

## Error with two annotations
I configured my project as explained in the repository and when I execute the maven compilation, this error occurs:

```java
Caused by: java.lang.StringIndexOutOfBoundsException: begin 0, end -1, length 96
    at java.lang.String.checkBoundsBeginEnd (String.java:3751)
    at java.lang.String.substring (String.java:1907)
    at com.speedment.jpastreamer.fieldgenerator.internal.typeparser.TypeParser.parseNode (TypeParser.java:56)
    at com.speedment.jpastreamer.fieldgenerator.internal.typeparser.TypeParser.render (TypeParser.java:36)
    at com.speedment.jpastreamer.fieldgenerator.internal.InternalFieldGeneratorProcessor.fieldType (InternalFieldGeneratorProcessor.java:321)
    at com.speedment.jpastreamer.fieldgenerator.internal.InternalFieldGeneratorProcessor.referenceType (InternalFieldGeneratorProcessor.java:281)
    at com.speedment.jpastreamer.fieldgenerator.internal.InternalFieldGeneratorProcessor.addFieldToClass (InternalFieldGeneratorProcessor.java:240)
    at com.speedment.jpastreamer.fieldgenerator.internal.InternalFieldGeneratorProcessor.lambda$generatedEntity$10 (InternalFieldGeneratorProcessor.java:223)
    at java.util.HashMap.forEach (HashMap.java:1425)
    at com.speedment.jpastreamer.fieldgenerator.internal.InternalFieldGeneratorProcessor.generatedEntity (InternalFieldGeneratorProcessor.java:222)
    at com.speedment.jpastreamer.fieldgenerator.internal.InternalFieldGeneratorProcessor.generateFields (InternalFieldGeneratorProcessor.java:165)
    at com.speedment.jpastreamer.fieldgenerator.internal.InternalFieldGeneratorProcessor.lambda$process$1 (InternalFieldGeneratorProcessor.java:103)
    at java.util.stream.ForEachOps$ForEachOp$OfRef.accept (ForEachOps.java:183)
    at java.util.stream.ReferencePipeline$2$1.accept (ReferencePipeline.java:179)
    at java.util.Iterator.forEachRemaining (Iterator.java:133)
    at java.util.Spliterators$IteratorSpliterator.forEachRemaining (Spliterators.java:1801)
    at java.util.stream.AbstractPipeline.copyInto (AbstractPipeline.java:484)
    at java.util.stream.AbstractPipeline.wrapAndCopyInto (AbstractPipeline.java:474)
    at java.util.stream.ForEachOps$ForEachOp.evaluateSequential (ForEachOps.java:150)
    at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential (ForEachOps.java:173)
    at java.util.stream.AbstractPipeline.evaluate (AbstractPipeline.java:234)
    at java.util.stream.ReferencePipeline.forEach (ReferencePipeline.java:596)
    at com.speedment.jpastreamer.fieldgenerator.internal.InternalFieldGeneratorProcessor.process (InternalFieldGeneratorProcessor.java:98)
    at com.speedment.jpastreamer.fieldgenerator.StandardFieldGeneratorProcessor.process (StandardFieldGeneratorProcessor.java:45)
    at com.sun.tools.javac.processing.JavacProcessingEnvironment.callProcessor (JavacProcessingEnvironment.java:1025)
    at com.sun.tools.javac.processing.JavacProcessingEnvironment.discoverAndRunProcs (JavacProcessingEnvironment.java:940)
    at com.sun.tools.javac.processing.JavacProcessingEnvironment$Round.run (JavacProcessingEnvironment.java:1269)
    at com.sun.tools.javac.processing.JavacProcessingEnvironment.doProcessing (JavacProcessingEnvironment.java:1384)
    at com.sun.tools.javac.main.JavaCompiler.processAnnotations (JavaCompiler.java:1261)
    at com.sun.tools.javac.main.JavaCompiler.compile (JavaCompiler.java:935)
    at com.sun.tools.javac.api.JavacTaskImpl.lambda$doCall$0 (JavacTaskImpl.java:104)
    at com.sun.tools.javac.api.JavacTaskImpl.invocationHelper (JavacTaskImpl.java:152)
    at com.sun.tools.javac.api.JavacTaskImpl.doCall (JavacTaskImpl.java:100)
    at com.sun.tools.javac.api.JavacTaskImpl.call (JavacTaskImpl.java:94)
    at org.codehaus.plexus.compiler.javac.JavaxToolsCompiler.compileInProcess (JavaxToolsCompiler.java:126)
    at org.codehaus.plexus.compiler.javac.JavacCompiler.performCompile (JavacCompiler.java:174)
    at org.apache.maven.plugin.compiler.AbstractCompilerMojo.execute (AbstractCompilerMojo.java:1134)
    at org.apache.maven.plugin.compiler.CompilerMojo.execute (CompilerMojo.java:187)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:78)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:567)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
```

## Debug
Debugging the compilation in the part that causes the error ( method `parseNode` of the class `TypeParser`):

```java
    private Node parseNode(String s) {
        // Base case returns leaf without children
        if (!(s.contains("<") || s.contains(","))) {
            return new Node(SimpleType.create(s));
        } else {
            Node node = new Node(SimpleType.create(s.substring(0, s.indexOf("<"))));
            List<String> params = parameters(s.substring(s.indexOf('<') + 1, s.lastIndexOf('>')));
            for (String param : params) { // Iterate to retain order of elements
                node.addChild(parseNode(param));
            }
            return node;
        }
    }
```

When the `TypeParser`  tries to extract the type from the field email the variable `s` has the following value 

```java
"@javax.validation.constraints.Email,@javax.validation.constraints.Size(max=255) java.lang.String"
```

Consequently, there is an error in the substring because it expects to find the char `<`.

## Error with one annotation
If I try to remove just one of the annotations and I execute the compilation again, another error occurs in the build:

```
[ERROR] /home/francesco/application/target/generated-sources/annotations/it/frascu/MyEntity$.java:[3,7] <identifier> expected
```

Now the string s has this value:

```java
"@javax.validation.constraints.Size(max=255) java.lang.String"
```

The class `MyEntity$` is not generated correctly because the import in the third row contains the type of the previous string `s`

```java
package it.frascu;

import @javax.validation.constraints.Size(max=255) java.lang.String;
...
```

## Solution
In the end, I decided to fix both the errors with this pull request considering that the string can contain annotations avoiding to take them in the string type. I added also some unit tests to check these cases.