### PR TITLE
Fix typos

### DIFF
--- a/docs/modules/how-it-works/pages/how-it-works.adoc
+++ b/docs/modules/how-it-works/pages/how-it-works.adoc
@@ -74,16 +74,16 @@ long nrOfFilmsStartingWithA = jpaStreamer.stream(Film.class)
     .filter(Film$.title.startsWith("A")) "<1>
     .count();
 ----
-#<1> As `title` is of type `StringField` we get access to operators such as `startsWith` that returns a `Predicate<T>` that evaluates to `true` or `false`.
+<1> As `title` is of type `StringField` we get access to operators such as `startsWith` that returns a `Predicate<T>` that evaluates to `true` or `false`.
 
 You can read more about the use of fields and predicates xref:predicates:predicates.adoc[here].
 
-NOTE: The metamodel is stored in the projects target-folder and does not need to be checked-in with your source code, nor needs testing.
+NOTE: The metamodel is stored in the projects target-folder and does not need to be checked-in with your source code, nor does it need testing.
 
 == The Stream renderer
-Most JPA providers, by default, has the ability to provide the query result as a `Stream`. That makes it possible to e.g. select all rows of a table and then use Stream operators to narrow the results. Although, that process requires every object of the table to be materialized by the JVM, which is not desired as it impedes the performance.
+Most JPA providers, by default, have the ability to provide the query result as a `Stream`. That makes it possible to e.g. select all rows of a table and then use Stream operators to narrow down the results. Although, that process requires every object of the table to be materialized by the JVM, which is not desired as it impedes the performance.
 
-As `Stream` is merely a Java interface, JPAstreamer if free to use a complete custom implementation of that interface. By doing so, JPAstreamer can render what seems like ordinary Streams to optimized JPA queries. The renderer inspects the Stream pipeline and translates the Stream operators to JPA constructs as shown below:
+As `Stream` is merely a Java interface, JPAstreamer is free to use a custom implementation of that interface. By doing so, JPAstreamer can render what seem like ordinary Streams to optimized JPA queries. The renderer inspects the Stream pipeline and translates the Stream operators to JPA constructs as shown below:
 
 [source, java]
 ----


### PR DESCRIPTION
I don't feel like filling out all the contribution stuff, feel free to copy my PR. Fixed some typos and removed the word complete. Complete is different from completely but I would just leave it away. I would also recommend to remove "style" words from the documentation. Like "By doing so, JPAStreamer can render ordinary Streams to optimized JPA queries" instead of "By doing so, JPAstreamer can render what seems like ordinary Streams to optimized JPA queries". Makes it easier for a dev that needs to glance over the documentation.