### PR TITLE
Fix phone home link in introduction page

### DIFF
--- a/docs/modules/introduction/pages/introduction.adoc
+++ b/docs/modules/introduction/pages/introduction.adoc
@@ -96,5 +96,5 @@ If you wish to learn more about the Java Stream API, start with the chapter xref
 - GitHub - https://github.com/speedment/jpa-streamer
 
 == Phone Home
-JPAstreamer sends certain anonymous usage data to Google Analytics as described link:https://github.com/speedment/jpa-streamer/blob/master/DISCLAIMER.MD[here]. If you wish to disable this feature, please contact us at info@jpastreamer.org.
+JPAstreamer sends certain anonymous usage data to Google Analytics as described link:https://github.com/speedment/jpa-streamer/blob/master/DISCLAIMER.md[here]. If you wish to disable this feature, please contact us at info@jpastreamer.org.
 


### PR DESCRIPTION
Currently, the link below is not working due to the difference in file extensions.
https://github.com/speedment/jpa-streamer/blob/master/DISCLAIMER.MD
