### PR TITLE
Migrate to JPA 3 

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -52,8 +52,9 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>${jakarta.version}</version>
         </dependency>
 
         <dependency>

--- a/application/src/main/java/com/speedment/jpastreamer/application/JPAStreamer.java
+++ b/application/src/main/java/com/speedment/jpastreamer/application/JPAStreamer.java
@@ -18,8 +18,8 @@ import com.speedment.jpastreamer.projection.Projection;
 import com.speedment.jpastreamer.rootfactory.RootFactory;
 import com.speedment.jpastreamer.streamconfiguration.StreamConfiguration;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
 import java.util.ServiceLoader;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -193,7 +193,7 @@ public interface JPAStreamer {
     /**
      * Resets the Streamer associated with the provided Entity classes.
      * <p> 
-     * This will create a new instance of the underlying {@code java.persistence.EntityManager}, removing all entries of the 
+     * This will create a new instance of the underlying {@code jakarta.persistence.EntityManager}, removing all entries of the 
      * associated Entity class from the first-level cache. 
      * 
      * In case JPAStreamer was configured with a {@code Supplier<EntityManager>} the lifecycle of the Entity Managers is 

--- a/application/src/main/java/com/speedment/jpastreamer/application/JPAStreamerBuilderFactory.java
+++ b/application/src/main/java/com/speedment/jpastreamer/application/JPAStreamerBuilderFactory.java
@@ -12,8 +12,8 @@
  */
 package com.speedment.jpastreamer.application;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
 import java.util.function.Supplier;
 
 public interface JPAStreamerBuilderFactory {

--- a/application/src/main/java9/module-info.java
+++ b/application/src/main/java9/module-info.java
@@ -11,7 +11,7 @@
  * See: https://github.com/speedment/jpa-streamer/blob/master/LICENSE
  */
 module jpastreamer.application {
-    requires transitive java.persistence;
+    requires transitive jakarta.persistence;
     requires transitive jpastreamer.field;
     requires transitive jpastreamer.streamconfiguration;
     requires jpastreamer.rootfactory;

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -37,8 +37,9 @@
     <dependencies>
 
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>${jakarta.version}</version>
         </dependency>
 
         <dependency>

--- a/core/src/main/java9/module-info.java
+++ b/core/src/main/java9/module-info.java
@@ -13,7 +13,7 @@
 module jpastreamer.core {
     exports com.speedment.jpastreamer.core;
 
-    requires transitive java.persistence;
+    requires transitive jakarta.persistence;
     requires transitive jpastreamer.application;
     requires transitive jpastreamer.field;
 

--- a/criteria/pom.xml
+++ b/criteria/pom.xml
@@ -41,9 +41,11 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>${jakarta.version}</version>
         </dependency>
+        
     </dependencies>
 
 </project>

--- a/criteria/src/main/java/com/speedment/jpastreamer/criteria/Criteria.java
+++ b/criteria/src/main/java/com/speedment/jpastreamer/criteria/Criteria.java
@@ -12,9 +12,9 @@
  */
 package com.speedment.jpastreamer.criteria;
 
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Root;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
 import java.util.List;
 
 /**

--- a/criteria/src/main/java/com/speedment/jpastreamer/criteria/CriteriaFactory.java
+++ b/criteria/src/main/java/com/speedment/jpastreamer/criteria/CriteriaFactory.java
@@ -14,10 +14,10 @@ package com.speedment.jpastreamer.criteria;
 
 import static java.util.Objects.requireNonNull;
 
-import javax.persistence.EntityManager;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Root;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
 
 /**
  * @author Mislav Milicevic

--- a/criteria/src/main/java/com/speedment/jpastreamer/criteria/OrderFactory.java
+++ b/criteria/src/main/java/com/speedment/jpastreamer/criteria/OrderFactory.java
@@ -12,7 +12,7 @@
  */
 package com.speedment.jpastreamer.criteria;
 
-import javax.persistence.criteria.Order;
+import jakarta.persistence.criteria.Order;
 import java.util.Comparator;
 import java.util.List;
 

--- a/criteria/src/main/java/com/speedment/jpastreamer/criteria/PredicateFactory.java
+++ b/criteria/src/main/java/com/speedment/jpastreamer/criteria/PredicateFactory.java
@@ -14,7 +14,7 @@ package com.speedment.jpastreamer.criteria;
 
 import com.speedment.jpastreamer.field.predicate.SpeedmentPredicate;
 
-import javax.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Predicate;
 
 /**
  * @author Mislav Milicevic

--- a/criteria/src/main/java/com/speedment/jpastreamer/criteria/QueryParameter.java
+++ b/criteria/src/main/java/com/speedment/jpastreamer/criteria/QueryParameter.java
@@ -12,7 +12,7 @@
  */
 package com.speedment.jpastreamer.criteria;
 
-import javax.persistence.criteria.ParameterExpression;
+import jakarta.persistence.criteria.ParameterExpression;
 
 /**
  * Stores a query parameter and the value associated with the parameter

--- a/criteria/src/main/java9/module-info.java
+++ b/criteria/src/main/java9/module-info.java
@@ -11,7 +11,7 @@
  * See: https://github.com/speedment/jpa-streamer/blob/master/LICENSE
  */
 module jpastreamer.criteria {
-    requires transitive java.persistence;
+    requires transitive jakarta.persistence;
     requires transitive jpastreamer.field;
 
     exports com.speedment.jpastreamer.criteria;

--- a/field/pom.xml
+++ b/field/pom.xml
@@ -39,8 +39,9 @@
     <dependencies>
 
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>${jakarta.version}</version>
         </dependency>
 
         <dependency>

--- a/field/src/main/java/com/speedment/jpastreamer/field/internal/ByteFieldImpl.java
+++ b/field/src/main/java/com/speedment/jpastreamer/field/internal/ByteFieldImpl.java
@@ -24,7 +24,6 @@ import com.speedment.jpastreamer.field.predicate.FieldPredicate;
 import com.speedment.jpastreamer.field.predicate.Inclusion;
 import com.speedment.jpastreamer.field.predicate.SpeedmentPredicate;
 
-import javax.persistence.AttributeConverter;
 import java.util.Collection;
 
 import static com.speedment.jpastreamer.field.internal.util.CollectionUtil.collectionToSet;

--- a/field/src/main/java/com/speedment/jpastreamer/field/trait/HasAttributeConverterClass.java
+++ b/field/src/main/java/com/speedment/jpastreamer/field/trait/HasAttributeConverterClass.java
@@ -12,7 +12,7 @@
  */
 package com.speedment.jpastreamer.field.trait;
 
-import javax.persistence.AttributeConverter;
+import jakarta.persistence.AttributeConverter;
 
 /**
  *

--- a/field/src/main/java9/module-info.java
+++ b/field/src/main/java9/module-info.java
@@ -12,7 +12,7 @@
  */
 module jpastreamer.field {
     requires com.speedment.common.invariant;
-    requires transitive java.persistence; // We expose this in fields via AttributeConverter
+    requires transitive jakarta.persistence; // We expose this in fields via AttributeConverter
 
     requires transitive com.speedment.common.function;
     requires transitive com.speedment.runtime.compute;

--- a/fieldgenerator/fieldgenerator-component/pom.xml
+++ b/fieldgenerator/fieldgenerator-component/pom.xml
@@ -38,8 +38,9 @@
     <dependencies>
 
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>${jakarta.version}</version>
         </dependency>
 
         <dependency>

--- a/fieldgenerator/fieldgenerator-component/src/main/java/com/speedment/jpastreamer/fieldgenerator/component/FilmTitleConverter.java
+++ b/fieldgenerator/fieldgenerator-component/src/main/java/com/speedment/jpastreamer/fieldgenerator/component/FilmTitleConverter.java
@@ -12,8 +12,8 @@
  */
 package com.speedment.jpastreamer.fieldgenerator.component;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 
 @Converter
 public class FilmTitleConverter implements

--- a/fieldgenerator/fieldgenerator-component/src/main/java9/module-info.java
+++ b/fieldgenerator/fieldgenerator-component/src/main/java9/module-info.java
@@ -11,7 +11,7 @@
  * See: https://github.com/speedment/jpa-streamer/blob/master/LICENSE
  */
 module jpastreamer.fieldgenerator.component {
-    requires java.persistence;
+    requires jakarta.persistence;
 
     exports com.speedment.jpastreamer.fieldgenerator.component;
 }

--- a/fieldgenerator/fieldgenerator-standard/pom.xml
+++ b/fieldgenerator/fieldgenerator-standard/pom.xml
@@ -38,8 +38,9 @@
     <dependencies>
 
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>${jakarta.version}</version>
         </dependency>
 
         <dependency>
@@ -129,8 +130,6 @@
             </build>
         </profile>
     </profiles>
-
-
 
     <!--    <profiles>
             <profile>

--- a/fieldgenerator/fieldgenerator-standard/src/main/java/com/speedment/jpastreamer/fieldgenerator/StandardFieldGeneratorProcessor.java
+++ b/fieldgenerator/fieldgenerator-standard/src/main/java/com/speedment/jpastreamer/fieldgenerator/StandardFieldGeneratorProcessor.java
@@ -28,7 +28,7 @@ import java.util.Set;
  * @since 0.1.0
  */
 
-@SupportedAnnotationTypes("javax.persistence.Entity")
+@SupportedAnnotationTypes("jakarta.persistence.Entity")
 @SupportedOptions({"jpaStreamerPackage", "jpaStreamerPrefix", "jpaStreamerSuffix"})
 @SupportedSourceVersion(SourceVersion.RELEASE_8)
 @AutoService(Processor.class)

--- a/fieldgenerator/fieldgenerator-standard/src/main/java/com/speedment/jpastreamer/fieldgenerator/internal/InternalFieldGeneratorProcessor.java
+++ b/fieldgenerator/fieldgenerator-standard/src/main/java/com/speedment/jpastreamer/fieldgenerator/internal/InternalFieldGeneratorProcessor.java
@@ -26,6 +26,10 @@ import com.speedment.jpastreamer.fieldgenerator.exception.FieldGeneratorProcesso
 import com.speedment.jpastreamer.fieldgenerator.internal.typeparser.TypeParser;
 import com.speedment.jpastreamer.field.*;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Lob;
+
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
@@ -35,16 +39,13 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Lob;
+
 import javax.tools.Diagnostic;
 import javax.tools.JavaFileObject;
 import java.io.IOException;
 import java.io.Writer;
 import java.lang.reflect.Type;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/fieldgenerator/fieldgenerator-standard/src/main/java9/module-info.java
+++ b/fieldgenerator/fieldgenerator-standard/src/main/java9/module-info.java
@@ -15,7 +15,7 @@ module jpastreamer.fieldgenerator.standard {
     requires transitive com.google.auto.service;
 
     requires com.speedment.common.codegen;
-    requires java.persistence;
+    requires jakarta.persistence;
     requires jpastreamer.field;
 
     exports com.speedment.jpastreamer.fieldgenerator;

--- a/fieldgenerator/fieldgenerator-test-package/pom.xml
+++ b/fieldgenerator/fieldgenerator-test-package/pom.xml
@@ -38,8 +38,9 @@
     <dependencies>
 
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>${jakarta.version}</version>
         </dependency>
 
         <dependency>

--- a/fieldgenerator/fieldgenerator-test-package/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/renaming/Actor.java
+++ b/fieldgenerator/fieldgenerator-test-package/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/renaming/Actor.java
@@ -10,13 +10,13 @@
  *
  * See: https://github.com/speedment/jpa-streamer/blob/master/LICENSE
  */
-package com.speedment.jpastreamer.fieldgenerator.renaming;
+package com.speedment.jpastreamer.fieldgenerator.test.renaming;
 
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Getter;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/fieldgenerator/fieldgenerator-test-package/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/renaming/Film.java
+++ b/fieldgenerator/fieldgenerator-test-package/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/renaming/Film.java
@@ -10,9 +10,9 @@
  *
  * See: https://github.com/speedment/jpa-streamer/blob/master/LICENSE
  */
-package com.speedment.jpastreamer.fieldgenerator.renaming;
+package com.speedment.jpastreamer.fieldgenerator.test.renaming;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.sql.Time;
 import java.time.LocalDateTime;
 import java.util.*;

--- a/fieldgenerator/fieldgenerator-test-package/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/renaming/Language.java
+++ b/fieldgenerator/fieldgenerator-test-package/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/renaming/Language.java
@@ -10,9 +10,9 @@
  *
  * See: https://github.com/speedment/jpa-streamer/blob/master/LICENSE
  */
-package com.speedment.jpastreamer.fieldgenerator.renaming;
+package com.speedment.jpastreamer.fieldgenerator.test.renaming;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.io.Serializable;
 import java.util.Set;
 

--- a/fieldgenerator/fieldgenerator-test-package/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/renaming/Main.java
+++ b/fieldgenerator/fieldgenerator-test-package/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/renaming/Main.java
@@ -10,11 +10,7 @@
  *
  * See: https://github.com/speedment/jpa-streamer/blob/master/LICENSE
  */
-package com.speedment.jpastreamer.fieldgenerator.renaming;
-
-import com.speedment.jpastreamer.fieldgenerator.test.renaming.inner.FilmB;
-
-import java.util.stream.Stream;
+package com.speedment.jpastreamer.fieldgenerator.test.renaming;
 
 public class Main {
 
@@ -32,11 +28,11 @@ public class Main {
         spindel.setLength(110);
 
         // Make sure generation is actually done
-        Stream.of(olle, spindel)
+        /*Stream.of(olle, spindel)
                 .filter(FilmB.length.between(100, 150))
                 .filter(FilmB.rating.in("G", "PG"))
                 .sorted(FilmB.title)
                 .forEachOrdered(System.out::println);
-
+        */
     }
 }

--- a/fieldgenerator/fieldgenerator-test-package/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/renaming/Main.java
+++ b/fieldgenerator/fieldgenerator-test-package/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/renaming/Main.java
@@ -12,6 +12,10 @@
  */
 package com.speedment.jpastreamer.fieldgenerator.test.renaming;
 
+import com.speedment.jpastreamer.fieldgenerator.test.renaming.inner.FilmB;
+
+import java.util.stream.Stream;
+
 public class Main {
 
     public static void main(String[] args) {
@@ -28,11 +32,11 @@ public class Main {
         spindel.setLength(110);
 
         // Make sure generation is actually done
-        /*Stream.of(olle, spindel)
+        Stream.of(olle, spindel)
                 .filter(FilmB.length.between(100, 150))
                 .filter(FilmB.rating.in("G", "PG"))
                 .sorted(FilmB.title)
                 .forEachOrdered(System.out::println);
-        */
+        
     }
 }

--- a/fieldgenerator/fieldgenerator-test-package/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/renaming/User.java
+++ b/fieldgenerator/fieldgenerator-test-package/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/renaming/User.java
@@ -10,10 +10,9 @@
  *
  * See: https://github.com/speedment/jpa-streamer/blob/master/LICENSE
  */
-package com.speedment.jpastreamer.fieldgenerator.renaming;
+package com.speedment.jpastreamer.fieldgenerator.test.renaming;
 
-import javax.persistence.*;
-
+import jakarta.persistence.*;
 @Entity
 public class User {
 

--- a/fieldgenerator/fieldgenerator-test-package/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/renaming/User2.java
+++ b/fieldgenerator/fieldgenerator-test-package/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/renaming/User2.java
@@ -10,9 +10,9 @@
  *
  * See: https://github.com/speedment/jpa-streamer/blob/master/LICENSE
  */
-package com.speedment.jpastreamer.fieldgenerator.renaming;
+package com.speedment.jpastreamer.fieldgenerator.test.renaming;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import javax.validation.constraints.NotEmpty;
 
 import java.io.Serializable;
@@ -21,6 +21,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
 @Entity
 @Table(name="user")
 @Data

--- a/fieldgenerator/fieldgenerator-test-package/src/main/java9/module-info.java
+++ b/fieldgenerator/fieldgenerator-test-package/src/main/java9/module-info.java
@@ -13,10 +13,10 @@
 module jpastreamer.fieldgenerator.test.renaming {
 
     requires jpastreamer.fieldgenerator.standard;
-    requires java.persistence;
+    requires jakarta.persistence;
     requires transitive java.sql;
     requires transitive jpastreamer.field;
 
-    exports com.speedment.jpastreamer.fieldgenerator.test.renaming.inner; 
+    exports com.speedment.jpastreamer.fieldgenerator.test.renaming;  
 
 }

--- a/fieldgenerator/fieldgenerator-test/pom.xml
+++ b/fieldgenerator/fieldgenerator-test/pom.xml
@@ -38,8 +38,9 @@
     <dependencies>
 
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>${jakarta.version}</version>
         </dependency>
 
         <dependency>

--- a/fieldgenerator/fieldgenerator-test/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/Actor.java
+++ b/fieldgenerator/fieldgenerator-test/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/Actor.java
@@ -16,7 +16,7 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Getter;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/fieldgenerator/fieldgenerator-test/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/Film.java
+++ b/fieldgenerator/fieldgenerator-test/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/Film.java
@@ -12,7 +12,7 @@
  */
 package com.speedment.jpastreamer.fieldgenerator.test;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.sql.Time;
 import java.time.LocalDateTime;
 import java.util.*;

--- a/fieldgenerator/fieldgenerator-test/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/Language.java
+++ b/fieldgenerator/fieldgenerator-test/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/Language.java
@@ -13,7 +13,7 @@
 package com.speedment.jpastreamer.fieldgenerator.test;
 
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.io.Serializable;
 import java.util.Set;
 

--- a/fieldgenerator/fieldgenerator-test/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/Lombok2Bean.java
+++ b/fieldgenerator/fieldgenerator-test/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/Lombok2Bean.java
@@ -15,7 +15,7 @@ package com.speedment.jpastreamer.fieldgenerator.test;
 import lombok.AccessLevel;
 import lombok.Getter;
 
-import javax.persistence.Entity;
+import jakarta.persistence.Entity;
 
 @Entity
 public class Lombok2Bean {

--- a/fieldgenerator/fieldgenerator-test/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/Lombok3Bean.java
+++ b/fieldgenerator/fieldgenerator-test/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/Lombok3Bean.java
@@ -15,7 +15,8 @@ package com.speedment.jpastreamer.fieldgenerator.test;
 import lombok.AccessLevel;
 import lombok.Getter;
 
-import javax.persistence.Entity;
+import jakarta.persistence.Entity;
+
 
 @Getter
 @Entity

--- a/fieldgenerator/fieldgenerator-test/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/LombokBean.java
+++ b/fieldgenerator/fieldgenerator-test/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/LombokBean.java
@@ -12,9 +12,9 @@
  */
 package com.speedment.jpastreamer.fieldgenerator.test;
 
-import lombok.Data;
+import jakarta.persistence.Entity;
 
-import javax.persistence.Entity;
+import lombok.Data;
 
 @Data
 @Entity

--- a/fieldgenerator/fieldgenerator-test/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/Main.java
+++ b/fieldgenerator/fieldgenerator-test/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/Main.java
@@ -13,7 +13,6 @@
 package com.speedment.jpastreamer.fieldgenerator.test;
 
 import java.util.stream.Stream;
-
 public class Main {
 
     public static void main(String[] args) {
@@ -30,12 +29,12 @@ public class Main {
         spindel.setLength(110);
 
         // Make sure generation is actually done
-        Stream.of(olle, spindel)
+        /*Stream.of(olle, spindel)
                 .filter(Film$.length.between(100, 150))
                 .filter(Film$.rating.in("G", "PG"))
                 .sorted(Film$.title)
                 .forEachOrdered(System.out::println);
-
+*/
         // Make sure Lombok methods gets generated
         Lombok3Bean lombok3Bean = new Lombok3Bean();
         lombok3Bean.getName();

--- a/fieldgenerator/fieldgenerator-test/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/Main.java
+++ b/fieldgenerator/fieldgenerator-test/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/Main.java
@@ -29,12 +29,12 @@ public class Main {
         spindel.setLength(110);
 
         // Make sure generation is actually done
-        /*Stream.of(olle, spindel)
+        Stream.of(olle, spindel)
                 .filter(Film$.length.between(100, 150))
                 .filter(Film$.rating.in("G", "PG"))
                 .sorted(Film$.title)
                 .forEachOrdered(System.out::println);
-*/
+
         // Make sure Lombok methods gets generated
         Lombok3Bean lombok3Bean = new Lombok3Bean();
         lombok3Bean.getName();

--- a/fieldgenerator/fieldgenerator-test/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/NonJavaBean.java
+++ b/fieldgenerator/fieldgenerator-test/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/NonJavaBean.java
@@ -12,7 +12,7 @@
  */
 package com.speedment.jpastreamer.fieldgenerator.test;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Entity
 @Table(name = "non_java_bean")

--- a/fieldgenerator/fieldgenerator-test/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/User.java
+++ b/fieldgenerator/fieldgenerator-test/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/User.java
@@ -12,7 +12,7 @@
  */
 package com.speedment.jpastreamer.fieldgenerator.test;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Entity
 public class User {

--- a/fieldgenerator/fieldgenerator-test/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/User2.java
+++ b/fieldgenerator/fieldgenerator-test/src/main/java/com/speedment/jpastreamer/fieldgenerator/test/User2.java
@@ -12,7 +12,7 @@
  */
 package com.speedment.jpastreamer.fieldgenerator.test;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import javax.validation.constraints.NotEmpty;
 
 import java.io.Serializable;

--- a/fieldgenerator/fieldgenerator-test/src/main/java9/module-info.java
+++ b/fieldgenerator/fieldgenerator-test/src/main/java9/module-info.java
@@ -13,7 +13,7 @@
 module jpastreamer.fieldgenerator.test {
 
     requires jpastreamer.fieldgenerator.standard;
-    requires java.persistence;
+    requires jakarta.persistence;
     requires transitive java.sql;
     requires transitive jpastreamer.field;
 

--- a/integration/cdi/cdi-jpastreamer/src/main/java/com/speedment/jpastreamer/integration/cdi/JPAStreamerProducer.java
+++ b/integration/cdi/cdi-jpastreamer/src/main/java/com/speedment/jpastreamer/integration/cdi/JPAStreamerProducer.java
@@ -13,10 +13,10 @@
 package com.speedment.jpastreamer.integration.cdi;
 
 import com.speedment.jpastreamer.application.JPAStreamer;
+import jakarta.persistence.EntityManagerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
-import javax.persistence.EntityManagerFactory;
 
 /**
  * A CDI class that adds support for JPAStreamer injection.

--- a/integration/spring/spring-boot-jpastreamer-autoconfigure/src/main/java/com/speedment/jpastreamer/integration/spring/autoconfigure/JPAStreamerAutoConfiguration.java
+++ b/integration/spring/spring-boot-jpastreamer-autoconfigure/src/main/java/com/speedment/jpastreamer/integration/spring/autoconfigure/JPAStreamerAutoConfiguration.java
@@ -13,12 +13,13 @@
 package com.speedment.jpastreamer.integration.spring.autoconfigure;
 
 import com.speedment.jpastreamer.application.JPAStreamer;
+
+import jakarta.persistence.EntityManagerFactory;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import javax.persistence.EntityManagerFactory;
 
 /**
  * A Spring Boot autoconfiguration class that adds support for JPAStreamer autowiring.

--- a/merger/pom.xml
+++ b/merger/pom.xml
@@ -46,8 +46,9 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>${jakarta.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/merger/src/main/java/com/speedment/jpastreamer/merger/QueryMerger.java
+++ b/merger/src/main/java/com/speedment/jpastreamer/merger/QueryMerger.java
@@ -14,9 +14,7 @@ package com.speedment.jpastreamer.merger;
 
 import com.speedment.jpastreamer.merger.result.QueryMergeResult;
 import com.speedment.jpastreamer.pipeline.Pipeline;
-
-import javax.persistence.Query;
-
+import jakarta.persistence.Query;
 
 /**
  * A stream operation merger used to apply offsets and limits to provided queries.

--- a/merger/src/main/java/com/speedment/jpastreamer/merger/result/QueryMergeResult.java
+++ b/merger/src/main/java/com/speedment/jpastreamer/merger/result/QueryMergeResult.java
@@ -13,8 +13,7 @@
 package com.speedment.jpastreamer.merger.result;
 
 import com.speedment.jpastreamer.pipeline.Pipeline;
-
-import javax.persistence.Query;
+import jakarta.persistence.Query;
 
 /**
  * A container object used to store the results of the merge operation

--- a/merger/src/main/java9/module-info.java
+++ b/merger/src/main/java9/module-info.java
@@ -11,7 +11,7 @@
  * See: https://github.com/speedment/jpa-streamer/blob/master/LICENSE
  */
 module jpastreamer.merger {
-    requires transitive java.persistence;
+    requires transitive jakarta.persistence;
     requires transitive jpastreamer.pipeline;
     requires transitive jpastreamer.criteria;
 

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
 
         <!-- later maven-javadoc-plugin versions does not support aggregate? -->
         <jpa.version>2.2</jpa.version>
+        <jakarta.version>3.1.0</jakarta.version>
         <maven-javadoc-plugin-version>3.5.0</maven-javadoc-plugin-version>
         <maven-source-plugin-version>3.2.1</maven-source-plugin-version>
         <maven-dependency-plugin-version>3.3.0</maven-dependency-plugin-version>
@@ -1042,9 +1043,9 @@
             </dependency>
 
             <dependency>
-                <groupId>javax.persistence</groupId>
-                <artifactId>javax.persistence-api</artifactId>
-                <version>${jpa.version}</version>
+                <groupId>jakarta.persistence</groupId>
+                <artifactId>jakarta.persistence-api</artifactId>
+                <version>${jakarta.version}</version>
             </dependency>
             
             <!-- Test Dependencies -->

--- a/projection/pom.xml
+++ b/projection/pom.xml
@@ -40,8 +40,9 @@
             <artifactId>field</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>${jakarta.version}</version>
         </dependency>
     </dependencies>
 

--- a/projection/src/main/java/com/speedment/jpastreamer/projection/Projection.java
+++ b/projection/src/main/java/com/speedment/jpastreamer/projection/Projection.java
@@ -16,8 +16,8 @@ import static java.util.Objects.requireNonNull;
 
 import com.speedment.jpastreamer.field.Field;
 import com.speedment.jpastreamer.projection.internal.InternalProjection;
+import jakarta.persistence.Tuple;
 
-import javax.persistence.Tuple;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;

--- a/projection/src/main/java/com/speedment/jpastreamer/projection/internal/InternalProjection.java
+++ b/projection/src/main/java/com/speedment/jpastreamer/projection/internal/InternalProjection.java
@@ -16,8 +16,8 @@ import static java.util.Objects.requireNonNull;
 
 import com.speedment.jpastreamer.field.Field;
 import com.speedment.jpastreamer.projection.Projection;
+import jakarta.persistence.Tuple;
 
-import javax.persistence.Tuple;
 import java.util.Collections;
 import java.util.Set;
 

--- a/projection/src/main/java/com/speedment/jpastreamer/projection/internal/StandardTupleElement.java
+++ b/projection/src/main/java/com/speedment/jpastreamer/projection/internal/StandardTupleElement.java
@@ -12,7 +12,7 @@
  */
 package com.speedment.jpastreamer.projection.internal;
 
-import javax.persistence.TupleElement;
+import jakarta.persistence.TupleElement;
 
 import java.util.Objects;
 

--- a/projection/src/main/java/com/speedment/jpastreamer/projection/internal/TupleContext.java
+++ b/projection/src/main/java/com/speedment/jpastreamer/projection/internal/TupleContext.java
@@ -13,9 +13,9 @@
 package com.speedment.jpastreamer.projection.internal;
 
 import com.speedment.jpastreamer.field.*;
+import jakarta.persistence.Tuple;
+import jakarta.persistence.TupleElement;
 
-import javax.persistence.Tuple;
-import javax.persistence.TupleElement;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;

--- a/projection/src/main/java9/module-info.java
+++ b/projection/src/main/java9/module-info.java
@@ -12,7 +12,7 @@
  */
 module jpastreamer.projection {
     requires transitive jpastreamer.field;
-    requires transitive java.persistence;
+    requires transitive jakarta.persistence;
 
     exports com.speedment.jpastreamer.projection;
 }

--- a/provider/application-standard/pom.xml
+++ b/provider/application-standard/pom.xml
@@ -82,8 +82,9 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>${jakarta.version}</version>
         </dependency>
 
     </dependencies>

--- a/provider/application-standard/src/main/java/com/speedment/jpastreamer/application/standard/StandardJPAStreamerBuilderFactory.java
+++ b/provider/application-standard/src/main/java/com/speedment/jpastreamer/application/standard/StandardJPAStreamerBuilderFactory.java
@@ -15,9 +15,8 @@ package com.speedment.jpastreamer.application.standard;
 import com.speedment.jpastreamer.application.JPAStreamerBuilder;
 import com.speedment.jpastreamer.application.JPAStreamerBuilderFactory;
 import com.speedment.jpastreamer.application.standard.internal.StandardJPAStreamerBuilder;
-
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
 
 import java.util.function.Supplier;
 

--- a/provider/application-standard/src/main/java/com/speedment/jpastreamer/application/standard/internal/StandardJPAStreamer.java
+++ b/provider/application-standard/src/main/java/com/speedment/jpastreamer/application/standard/internal/StandardJPAStreamer.java
@@ -22,8 +22,8 @@ import com.speedment.jpastreamer.application.JPAStreamer;
 import com.speedment.jpastreamer.rootfactory.RootFactory;
 import com.speedment.jpastreamer.streamconfiguration.StreamConfiguration;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityManager;
+
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;

--- a/provider/application-standard/src/main/java/com/speedment/jpastreamer/application/standard/internal/StandardJPAStreamerBuilder.java
+++ b/provider/application-standard/src/main/java/com/speedment/jpastreamer/application/standard/internal/StandardJPAStreamerBuilder.java
@@ -15,9 +15,9 @@ package com.speedment.jpastreamer.application.standard.internal;
 import com.speedment.jpastreamer.application.JPAStreamer;
 import com.speedment.jpastreamer.application.JPAStreamerBuilder;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.Persistence;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
 
 import java.util.function.Supplier;
 

--- a/provider/application-standard/src/main/java/com/speedment/jpastreamer/application/standard/internal/StandardStreamer.java
+++ b/provider/application-standard/src/main/java/com/speedment/jpastreamer/application/standard/internal/StandardStreamer.java
@@ -21,8 +21,9 @@ import com.speedment.jpastreamer.renderer.RendererFactory;
 import com.speedment.jpastreamer.rootfactory.RootFactory;
 import com.speedment.jpastreamer.streamconfiguration.StreamConfiguration;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
 import java.util.ServiceLoader;
 import java.util.function.Supplier;
 import java.util.stream.Stream;

--- a/provider/builder-standard/src/main/java/com/speedment/jpastreamer/builder/standard/internal/MockRendererFactory.java
+++ b/provider/builder-standard/src/main/java/com/speedment/jpastreamer/builder/standard/internal/MockRendererFactory.java
@@ -18,8 +18,9 @@ import com.speedment.jpastreamer.renderer.Renderer;
 import com.speedment.jpastreamer.renderer.RendererFactory;
 import com.speedment.jpastreamer.streamconfiguration.StreamConfiguration;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.stream.BaseStream;

--- a/provider/builder-standard/src/test/java/com/speedment/jpastreamer/builder/standard/internal/BaseStreamBuilderTest.java
+++ b/provider/builder-standard/src/test/java/com/speedment/jpastreamer/builder/standard/internal/BaseStreamBuilderTest.java
@@ -20,9 +20,9 @@ import com.speedment.jpastreamer.projection.Projection;
 import com.speedment.jpastreamer.renderer.RenderResult;
 import com.speedment.jpastreamer.renderer.Renderer;
 import com.speedment.jpastreamer.streamconfiguration.StreamConfiguration;
+import jakarta.persistence.criteria.JoinType;
 import org.junit.jupiter.api.BeforeEach;
 
-import javax.persistence.criteria.JoinType;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiPredicate;

--- a/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/StandardCriteriaFactory.java
+++ b/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/StandardCriteriaFactory.java
@@ -16,10 +16,10 @@ import com.speedment.jpastreamer.criteria.Criteria;
 import com.speedment.jpastreamer.criteria.CriteriaFactory;
 import com.speedment.jpastreamer.criteria.standard.internal.InternalCriteriaFactory;
 
-import javax.persistence.EntityManager;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Root;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
 
 public final class StandardCriteriaFactory implements CriteriaFactory {
 

--- a/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/StandardOrderFactory.java
+++ b/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/StandardOrderFactory.java
@@ -16,7 +16,7 @@ import com.speedment.jpastreamer.criteria.Criteria;
 import com.speedment.jpastreamer.criteria.OrderFactory;
 import com.speedment.jpastreamer.criteria.standard.internal.InternalOrderFactory;
 
-import javax.persistence.criteria.Order;
+import jakarta.persistence.criteria.Order;
 import java.util.Comparator;
 import java.util.List;
 

--- a/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/StandardPredicateFactory.java
+++ b/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/StandardPredicateFactory.java
@@ -17,7 +17,7 @@ import com.speedment.jpastreamer.criteria.PredicateFactory;
 import com.speedment.jpastreamer.criteria.standard.internal.InternalPredicateFactory;
 import com.speedment.jpastreamer.field.predicate.SpeedmentPredicate;
 
-import javax.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Predicate;
 
 public final class StandardPredicateFactory implements PredicateFactory {
 

--- a/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/internal/InternalCriteria.java
+++ b/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/internal/InternalCriteria.java
@@ -17,10 +17,10 @@ import static java.util.Objects.requireNonNull;
 
 import com.speedment.jpastreamer.criteria.Criteria;
 import com.speedment.jpastreamer.criteria.QueryParameter;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
 
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Root;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/internal/InternalCriteriaFactory.java
+++ b/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/internal/InternalCriteriaFactory.java
@@ -17,9 +17,9 @@ import static java.util.Objects.requireNonNull;
 import com.speedment.jpastreamer.criteria.Criteria;
 import com.speedment.jpastreamer.criteria.CriteriaFactory;
 
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Root;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
 
 public final class InternalCriteriaFactory implements CriteriaFactory {
 

--- a/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/internal/InternalOrderFactory.java
+++ b/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/internal/InternalOrderFactory.java
@@ -23,7 +23,7 @@ import com.speedment.jpastreamer.exception.JPAStreamerException;
 import com.speedment.jpastreamer.field.comparator.CombinedComparator;
 import com.speedment.jpastreamer.field.comparator.FieldComparator;
 
-import javax.persistence.criteria.Order;
+import jakarta.persistence.criteria.Order;
 import java.util.Comparator;
 import java.util.List;
 

--- a/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/internal/InternalPredicateFactory.java
+++ b/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/internal/InternalPredicateFactory.java
@@ -23,7 +23,7 @@ import com.speedment.jpastreamer.field.predicate.CombinedPredicate;
 import com.speedment.jpastreamer.field.predicate.FieldPredicate;
 import com.speedment.jpastreamer.field.predicate.SpeedmentPredicate;
 
-import javax.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Predicate;
 
 public final class InternalPredicateFactory implements PredicateFactory {
 

--- a/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/internal/InternalQueryParameter.java
+++ b/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/internal/InternalQueryParameter.java
@@ -13,8 +13,7 @@
 package com.speedment.jpastreamer.criteria.standard.internal;
 
 import com.speedment.jpastreamer.criteria.QueryParameter;
-
-import javax.persistence.criteria.ParameterExpression;
+import jakarta.persistence.criteria.ParameterExpression;
 
 public class InternalQueryParameter<T> implements QueryParameter<T> {
 

--- a/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/internal/order/DefaultOrderMapper.java
+++ b/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/internal/order/DefaultOrderMapper.java
@@ -17,10 +17,9 @@ import static java.util.Objects.requireNonNull;
 import com.speedment.jpastreamer.criteria.Criteria;
 import com.speedment.jpastreamer.field.Field;
 import com.speedment.jpastreamer.field.comparator.FieldComparator;
-
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.Order;
-import javax.persistence.criteria.Root;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Order;
+import jakarta.persistence.criteria.Root;
 
 public final class DefaultOrderMapper implements OrderMapper {
 

--- a/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/internal/order/OrderMapper.java
+++ b/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/internal/order/OrderMapper.java
@@ -15,7 +15,7 @@ package com.speedment.jpastreamer.criteria.standard.internal.order;
 import com.speedment.jpastreamer.criteria.Criteria;
 import com.speedment.jpastreamer.field.comparator.FieldComparator;
 
-import javax.persistence.criteria.Order;
+import jakarta.persistence.criteria.Order;
 
 public interface OrderMapper {
 

--- a/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/internal/predicate/DefaultPredicateMapper.java
+++ b/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/internal/predicate/DefaultPredicateMapper.java
@@ -28,10 +28,11 @@ import com.speedment.jpastreamer.field.predicate.trait.HasInclusion;
 import com.speedment.jpastreamer.field.trait.HasArg0;
 import com.speedment.jpastreamer.field.trait.HasArg1;
 
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.ParameterExpression;
-import javax.persistence.criteria.Path;
-import javax.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.ParameterExpression;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+
 import java.util.Set;
 import java.util.function.Function;
 

--- a/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/internal/predicate/ParameterizedPredicate.java
+++ b/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/internal/predicate/ParameterizedPredicate.java
@@ -12,10 +12,11 @@
  */
 package com.speedment.jpastreamer.criteria.standard.internal.predicate;
 
+import jakarta.persistence.criteria.ParameterExpression;
+import jakarta.persistence.criteria.Predicate;
+
 import static java.util.Objects.requireNonNull;
 
-import javax.persistence.criteria.ParameterExpression;
-import javax.persistence.criteria.Predicate;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 

--- a/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/internal/predicate/PredicateMapping.java
+++ b/provider/criteria-standard/src/main/java/com/speedment/jpastreamer/criteria/standard/internal/predicate/PredicateMapping.java
@@ -14,7 +14,7 @@ package com.speedment.jpastreamer.criteria.standard.internal.predicate;
 
 import com.speedment.jpastreamer.criteria.QueryParameter;
 
-import javax.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Predicate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/provider/criteria-standard/src/test/java/com/speedment/jpastreamer/criteria/standard/StandardCriteriaFactoryTest.java
+++ b/provider/criteria-standard/src/test/java/com/speedment/jpastreamer/criteria/standard/StandardCriteriaFactoryTest.java
@@ -18,12 +18,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.speedment.jpastreamer.criteria.CriteriaFactory;
-import org.junit.jupiter.api.Test;
 
-import javax.persistence.EntityManager;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Root;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+import org.junit.jupiter.api.Test;
 
 final class StandardCriteriaFactoryTest {
 

--- a/provider/criteria-standard/src/test/java/com/speedment/jpastreamer/criteria/standard/internal/InternalPredicateFactoryTest.java
+++ b/provider/criteria-standard/src/test/java/com/speedment/jpastreamer/criteria/standard/internal/InternalPredicateFactoryTest.java
@@ -29,10 +29,11 @@ import com.speedment.jpastreamer.exception.JPAStreamerException;
 import com.speedment.jpastreamer.field.predicate.CombinedPredicate.Type;
 import com.speedment.jpastreamer.field.predicate.FieldPredicate;
 import com.speedment.jpastreamer.field.predicate.SpeedmentPredicate;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.persistence.criteria.CriteriaBuilder;
 import java.util.Arrays;
 import java.util.Collections;
 

--- a/provider/merger-standard/pom.xml
+++ b/provider/merger-standard/pom.xml
@@ -67,8 +67,9 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>${jakarta.version}</version>
         </dependency>
 
     </dependencies>

--- a/provider/merger-standard/src/main/java/com/speedment/jpastreamer/merger/standard/internal/criteria/strategy/FilterCriteriaModifier.java
+++ b/provider/merger-standard/src/main/java/com/speedment/jpastreamer/merger/standard/internal/criteria/strategy/FilterCriteriaModifier.java
@@ -23,8 +23,8 @@ import com.speedment.jpastreamer.merger.standard.internal.tracker.MergingTracker
 import com.speedment.jpastreamer.pipeline.intermediate.IntermediateOperation;
 import com.speedment.jpastreamer.pipeline.intermediate.IntermediateOperationType;
 import com.speedment.jpastreamer.rootfactory.RootFactory;
+import jakarta.persistence.criteria.Predicate;
 
-import javax.persistence.criteria.Predicate;
 import java.util.Optional;
 import java.util.ServiceLoader;
 

--- a/provider/merger-standard/src/main/java/com/speedment/jpastreamer/merger/standard/internal/criteria/strategy/SortedCriteriaModifier.java
+++ b/provider/merger-standard/src/main/java/com/speedment/jpastreamer/merger/standard/internal/criteria/strategy/SortedCriteriaModifier.java
@@ -24,10 +24,11 @@ import com.speedment.jpastreamer.pipeline.intermediate.IntermediateOperation;
 import com.speedment.jpastreamer.pipeline.intermediate.IntermediateOperationType;
 import com.speedment.jpastreamer.rootfactory.RootFactory;
 
-import javax.persistence.criteria.Order;
-import javax.persistence.metamodel.Attribute;
-import javax.persistence.metamodel.EntityType;
-import javax.persistence.metamodel.SingularAttribute;
+import jakarta.persistence.criteria.Order;
+import jakarta.persistence.metamodel.Attribute;
+import jakarta.persistence.metamodel.EntityType;
+import jakarta.persistence.metamodel.SingularAttribute;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;

--- a/provider/merger-standard/src/main/java/com/speedment/jpastreamer/merger/standard/internal/query/InternalQueryMerger.java
+++ b/provider/merger-standard/src/main/java/com/speedment/jpastreamer/merger/standard/internal/query/InternalQueryMerger.java
@@ -23,7 +23,8 @@ import com.speedment.jpastreamer.pipeline.Pipeline;
 import com.speedment.jpastreamer.pipeline.intermediate.IntermediateOperation;
 import com.speedment.jpastreamer.pipeline.intermediate.IntermediateOperationType;
 
-import javax.persistence.Query;
+import jakarta.persistence.Query;
+
 import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.List;

--- a/provider/merger-standard/src/main/java/com/speedment/jpastreamer/merger/standard/internal/query/result/InternalQueryMergeResult.java
+++ b/provider/merger-standard/src/main/java/com/speedment/jpastreamer/merger/standard/internal/query/result/InternalQueryMergeResult.java
@@ -14,8 +14,7 @@ package com.speedment.jpastreamer.merger.standard.internal.query.result;
 
 import com.speedment.jpastreamer.merger.result.QueryMergeResult;
 import com.speedment.jpastreamer.pipeline.Pipeline;
-
-import javax.persistence.Query;
+import jakarta.persistence.Query;
 
 public final class InternalQueryMergeResult<T> implements QueryMergeResult<T> {
 

--- a/provider/merger-standard/src/main/java/com/speedment/jpastreamer/merger/standard/internal/query/strategy/QueryModifier.java
+++ b/provider/merger-standard/src/main/java/com/speedment/jpastreamer/merger/standard/internal/query/strategy/QueryModifier.java
@@ -14,8 +14,7 @@ package com.speedment.jpastreamer.merger.standard.internal.query.strategy;
 
 import com.speedment.jpastreamer.merger.standard.internal.reference.IntermediateOperationReference;
 import com.speedment.jpastreamer.merger.standard.internal.tracker.MergingTracker;
-
-import javax.persistence.Query;
+import jakarta.persistence.Query;
 
 /**
  * @author Mislav Milicevic

--- a/provider/merger-standard/src/main/java/com/speedment/jpastreamer/merger/standard/internal/query/strategy/SkipLimitModifier.java
+++ b/provider/merger-standard/src/main/java/com/speedment/jpastreamer/merger/standard/internal/query/strategy/SkipLimitModifier.java
@@ -20,8 +20,8 @@ import com.speedment.jpastreamer.merger.standard.internal.reference.Intermediate
 import com.speedment.jpastreamer.merger.standard.internal.tracker.MergingTracker;
 import com.speedment.jpastreamer.pipeline.intermediate.IntermediateOperation;
 import com.speedment.jpastreamer.pipeline.intermediate.IntermediateOperationType;
+import jakarta.persistence.Query;
 
-import javax.persistence.Query;
 import java.util.Optional;
 
 public enum SkipLimitModifier implements QueryModifier {

--- a/provider/renderer-standard/pom.xml
+++ b/provider/renderer-standard/pom.xml
@@ -67,8 +67,9 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>${jakarta.version}</version>
         </dependency>
 
 

--- a/provider/renderer-standard/src/main/java/com/speedment/jpastreamer/renderer/standard/StandardRendererFactory.java
+++ b/provider/renderer-standard/src/main/java/com/speedment/jpastreamer/renderer/standard/StandardRendererFactory.java
@@ -16,8 +16,9 @@ import com.speedment.jpastreamer.renderer.Renderer;
 import com.speedment.jpastreamer.renderer.RendererFactory;
 import com.speedment.jpastreamer.renderer.standard.internal.InternalRendererFactory;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
 import java.util.function.Supplier;
 
 public final class StandardRendererFactory implements RendererFactory {

--- a/provider/renderer-standard/src/main/java/com/speedment/jpastreamer/renderer/standard/internal/InternalRendererFactory.java
+++ b/provider/renderer-standard/src/main/java/com/speedment/jpastreamer/renderer/standard/internal/InternalRendererFactory.java
@@ -14,9 +14,9 @@ package com.speedment.jpastreamer.renderer.standard.internal;
 
 import com.speedment.jpastreamer.renderer.Renderer;
 import com.speedment.jpastreamer.renderer.RendererFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
 import java.util.function.Supplier;
 
 public final class InternalRendererFactory implements RendererFactory {

--- a/provider/renderer-standard/src/main/java/com/speedment/jpastreamer/renderer/standard/internal/StandardRenderer.java
+++ b/provider/renderer-standard/src/main/java/com/speedment/jpastreamer/renderer/standard/internal/StandardRenderer.java
@@ -29,12 +29,13 @@ import com.speedment.jpastreamer.renderer.Renderer;
 import com.speedment.jpastreamer.rootfactory.RootFactory;
 import com.speedment.jpastreamer.streamconfiguration.StreamConfiguration;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.TypedQuery;
-import javax.persistence.criteria.CompoundSelection;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Path;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CompoundSelection;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Path;
+
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.function.Supplier;

--- a/provider/streamconfiguration-standard/src/main/java/com/speedment/jpastreamer/streamconfiguration/standard/internal/StandardJoinConfiguration.java
+++ b/provider/streamconfiguration-standard/src/main/java/com/speedment/jpastreamer/streamconfiguration/standard/internal/StandardJoinConfiguration.java
@@ -14,8 +14,7 @@ package com.speedment.jpastreamer.streamconfiguration.standard.internal;
 
 import com.speedment.jpastreamer.field.Field;
 import com.speedment.jpastreamer.streamconfiguration.StreamConfiguration;
-
-import javax.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.JoinType;
 
 import static java.util.Objects.requireNonNull;
 

--- a/provider/streamconfiguration-standard/src/main/java/com/speedment/jpastreamer/streamconfiguration/standard/internal/StandardStreamConfiguration.java
+++ b/provider/streamconfiguration-standard/src/main/java/com/speedment/jpastreamer/streamconfiguration/standard/internal/StandardStreamConfiguration.java
@@ -17,8 +17,8 @@ import static java.util.Objects.requireNonNull;
 import com.speedment.jpastreamer.field.Field;
 import com.speedment.jpastreamer.projection.Projection;
 import com.speedment.jpastreamer.streamconfiguration.StreamConfiguration;
+import jakarta.persistence.criteria.JoinType;
 
-import javax.persistence.criteria.JoinType;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;

--- a/provider/streamconfiguration-standard/src/test/java/com/speedment/jpastreamer/streamconfiguration/standard/internal/StandardStreamConfigurationTest.java
+++ b/provider/streamconfiguration-standard/src/test/java/com/speedment/jpastreamer/streamconfiguration/standard/internal/StandardStreamConfigurationTest.java
@@ -14,10 +14,10 @@ package com.speedment.jpastreamer.streamconfiguration.standard.internal;
 
 import com.speedment.jpastreamer.field.Field;
 import com.speedment.jpastreamer.streamconfiguration.StreamConfiguration;
+import jakarta.persistence.criteria.JoinType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.persistence.criteria.JoinType;
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/renderer/pom.xml
+++ b/renderer/pom.xml
@@ -47,8 +47,9 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>${jakarta.version}</version>
         </dependency>
 
     </dependencies>

--- a/renderer/src/main/java/com/speedment/jpastreamer/renderer/RendererFactory.java
+++ b/renderer/src/main/java/com/speedment/jpastreamer/renderer/RendererFactory.java
@@ -12,8 +12,8 @@
  */
 package com.speedment.jpastreamer.renderer;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
 import java.util.function.Supplier;
 
 public interface RendererFactory {

--- a/renderer/src/main/java9/module-info.java
+++ b/renderer/src/main/java9/module-info.java
@@ -11,7 +11,7 @@
  * See: https://github.com/speedment/jpa-streamer/blob/master/LICENSE
  */
 module jpastreamer.renderer {
-    requires transitive java.persistence;
+    requires transitive jakarta.persistence;
     requires transitive jpastreamer.streamconfiguration;
     requires transitive jpastreamer.pipeline;
 

--- a/streamconfiguration/pom.xml
+++ b/streamconfiguration/pom.xml
@@ -52,8 +52,9 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>${jakarta.version}</version>
         </dependency>
 
     </dependencies>

--- a/streamconfiguration/src/main/java/com/speedment/jpastreamer/streamconfiguration/StreamConfiguration.java
+++ b/streamconfiguration/src/main/java/com/speedment/jpastreamer/streamconfiguration/StreamConfiguration.java
@@ -15,8 +15,8 @@ package com.speedment.jpastreamer.streamconfiguration;
 import com.speedment.jpastreamer.field.Field;
 import com.speedment.jpastreamer.projection.Projection;
 import com.speedment.jpastreamer.rootfactory.RootFactory;
+import jakarta.persistence.criteria.JoinType;
 
-import javax.persistence.criteria.JoinType;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;

--- a/streamconfiguration/src/main/java9/module-info.java
+++ b/streamconfiguration/src/main/java9/module-info.java
@@ -12,7 +12,7 @@
  */
 module jpastreamer.streamconfiguration {
     requires transitive jpastreamer.field;
-    requires transitive java.persistence;
+    requires transitive jakarta.persistence;
     requires transitive jpastreamer.projection; // To be removed
     requires jpastreamer.rootfactory;
 


### PR DESCRIPTION
This PR replaces all references to `javax.persistence` with `jakarta.persistence` to ensure compatibility with JPA 3 and Hibernate 6. 